### PR TITLE
Add support for frame piercing selector

### DIFF
--- a/Browser/wrapper/evaluation.ts
+++ b/Browser/wrapper/evaluation.ts
@@ -2,7 +2,7 @@ import { sendUnaryData, ServerUnaryCall } from 'grpc';
 import { Page } from 'playwright';
 
 import { Response, Request } from './generated/playwright_pb';
-import { invokeOnPage } from './playwirght-util';
+import { invokeOnPage, invokeOnPageWithSelector } from './playwirght-util';
 import { emptyWithLog, jsResponse } from './response-util';
 
 declare global {
@@ -33,7 +33,7 @@ export async function waitForElementState(
 ) {
     const selector = call.request.getSelector();
     const options = JSON.parse(call.request.getOptions());
-    await invokeOnPage(page, callback, 'waitForSelector', selector, options);
+    await invokeOnPageWithSelector(page, callback, 'waitForSelector', selector, options);
     callback(null, emptyWithLog('Wait for Element with selector: ' + selector));
 }
 
@@ -71,5 +71,5 @@ export async function highlightElements(
             }, duration);
         });
     };
-    await invokeOnPage(page, callback, '$$eval', selector, highlighter, duration);
+    await invokeOnPageWithSelector(page, callback, '$$eval', selector, highlighter, duration);
 }

--- a/Browser/wrapper/getters.ts
+++ b/Browser/wrapper/getters.ts
@@ -2,7 +2,7 @@ import { sendUnaryData, ServerUnaryCall } from 'grpc';
 import { Page, ElementHandle } from 'playwright';
 
 import { Response, Request, SelectEntry } from './generated/playwright_pb';
-import { invokeOnPage } from './playwirght-util';
+import { invokeOnPage, invokeOnPageWithSelector } from './playwirght-util';
 import { stringResponse, boolResponse, intResponse } from './response-util';
 
 export async function getTitle(callback: sendUnaryData<Response.String>, page?: Page) {
@@ -21,7 +21,7 @@ export async function getTextContent(
     page?: Page,
 ) {
     const selector = call.request.getSelector();
-    const content = invokeOnPage(page, callback, 'textContent', selector);
+    const content = invokeOnPageWithSelector(page, callback, 'textContent', selector);
     callback(null, stringResponse(content?.toString() || ''));
 }
 
@@ -31,7 +31,7 @@ export async function getElementCount(
     page?: Page,
 ) {
     const selector = call.request.getSelector();
-    const response: Array<ElementHandle> = await invokeOnPage(page, callback, '$$', selector);
+    const response: Array<ElementHandle> = await invokeOnPageWithSelector(page, callback, '$$', selector);
     callback(null, intResponse(response.length));
 }
 
@@ -43,8 +43,12 @@ export async function getSelectContent(
     const selector = call.request.getSelector();
 
     type Value = [string, string, boolean];
-    const content: Value[] = await invokeOnPage(page, callback, '$$eval', selector + ' option', (elements: any) =>
-        (elements as HTMLOptionElement[]).map((elem) => [elem.label, elem.value, elem.selected]),
+    const content: Value[] = await invokeOnPageWithSelector(
+        page,
+        callback,
+        '$$eval',
+        selector + ' option',
+        (elements: any) => (elements as HTMLOptionElement[]).map((elem) => [elem.label, elem.value, elem.selected]),
     );
 
     const response = new Response.Select();
@@ -79,7 +83,7 @@ export async function getBoolProperty(
 
 async function getProperty<T>(call: ServerUnaryCall<Request.ElementProperty>, callback: sendUnaryData<T>, page?: Page) {
     const selector = call.request.getSelector();
-    const element = await invokeOnPage(page, callback, '$', selector);
+    const element = await invokeOnPageWithSelector(page, callback, '$', selector);
     try {
         const propertyName = call.request.getProperty();
         const property = await element.getProperty(propertyName);

--- a/Browser/wrapper/interaction.ts
+++ b/Browser/wrapper/interaction.ts
@@ -2,7 +2,7 @@ import { sendUnaryData, ServerUnaryCall } from 'grpc';
 import { Page } from 'playwright';
 
 import { Response, Request } from './generated/playwright_pb';
-import { invokeOnPage } from './playwirght-util';
+import { invokeOnPage, invokeOnPageWithSelector } from './playwirght-util';
 import { emptyWithLog } from './response-util';
 
 export async function selectOption(
@@ -12,7 +12,7 @@ export async function selectOption(
 ) {
     const selector = call.request.getSelector();
     const matcher = JSON.parse(call.request.getMatcherjson());
-    const result = await invokeOnPage(page, callback, 'selectOption', selector, matcher);
+    const result = await invokeOnPageWithSelector(page, callback, 'selectOption', selector, matcher);
 
     if (result.length == 0) {
         console.log("Couldn't select any options");
@@ -29,7 +29,7 @@ export async function deSelectOption(
     page?: Page,
 ) {
     const selector = call.request.getSelector();
-    await invokeOnPage(page, callback, 'selectOption', selector, []);
+    await invokeOnPageWithSelector(page, callback, 'selectOption', selector, []);
     callback(null, emptyWithLog(`Deselected options in element ${selector}`));
 }
 
@@ -42,7 +42,7 @@ export async function inputText(
     const selector = call.request.getSelector();
     const type = call.request.getType();
     const methodName = type ? 'type' : 'fill';
-    await invokeOnPage(page, callback, methodName, selector, inputText);
+    await invokeOnPageWithSelector(page, callback, methodName, selector, inputText);
     callback(null, emptyWithLog('Input text: ' + inputText));
 }
 
@@ -56,9 +56,9 @@ export async function typeText(
     const delay = call.request.getDelay();
     const clear = call.request.getClear();
     if (clear) {
-        await invokeOnPage(page, callback, 'fill', selector, '');
+        await invokeOnPageWithSelector(page, callback, 'fill', selector, '');
     }
-    await invokeOnPage(page, callback, 'type', selector, text, { delay: delay });
+    await invokeOnPageWithSelector(page, callback, 'type', selector, text, { delay: delay });
     callback(null, emptyWithLog('Typed text: ' + text));
 }
 
@@ -69,7 +69,7 @@ export async function fillText(
 ) {
     const selector = call.request.getSelector();
     const text = call.request.getText();
-    await invokeOnPage(page, callback, 'fill', selector, text);
+    await invokeOnPageWithSelector(page, callback, 'fill', selector, text);
     callback(null, emptyWithLog('Fill text: ' + text));
 }
 
@@ -79,7 +79,7 @@ export async function clearText(
     page?: Page,
 ) {
     const selector = call.request.getSelector();
-    await invokeOnPage(page, callback, 'fill', selector, '');
+    await invokeOnPageWithSelector(page, callback, 'fill', selector, '');
     callback(null, emptyWithLog('Text field cleared.'));
 }
 
@@ -91,7 +91,7 @@ export async function press(
     const selector = call.request.getSelector();
     const keyList = call.request.getKeyList();
     for (const i of keyList) {
-        await invokeOnPage(page, callback, 'press', selector, i);
+        await invokeOnPageWithSelector(page, callback, 'press', selector, i);
     }
     callback(null, emptyWithLog('Pressed keys: ' + keyList));
 }
@@ -102,7 +102,7 @@ export async function click(
     page?: Page,
 ) {
     const selector = call.request.getSelector();
-    await invokeOnPage(page, callback, 'click', selector);
+    await invokeOnPageWithSelector(page, callback, 'click', selector);
     callback(null, emptyWithLog('Clicked element: ' + selector));
 }
 
@@ -113,7 +113,7 @@ export async function clickWithOptions(
 ) {
     const selector = call.request.getSelector();
     const options = call.request.getOptions();
-    await invokeOnPage(page, callback, 'click', selector, JSON.parse(options));
+    await invokeOnPageWithSelector(page, callback, 'click', selector, JSON.parse(options));
     callback(null, emptyWithLog('Clicked element: ' + selector + ' \nWith options: ' + options));
 }
 
@@ -123,7 +123,7 @@ export async function focus(
     page?: Page,
 ) {
     const selector = call.request.getSelector();
-    await invokeOnPage(page, callback, 'focus', selector);
+    await invokeOnPageWithSelector(page, callback, 'focus', selector);
     callback(null, emptyWithLog('Focused element: ' + selector));
 }
 
@@ -133,7 +133,7 @@ export async function checkCheckbox(
     page?: Page,
 ) {
     const selector = call.request.getSelector();
-    await invokeOnPage(page, callback, 'check', selector);
+    await invokeOnPageWithSelector(page, callback, 'check', selector);
     callback(null, emptyWithLog('Checked checkbox: ' + selector));
 }
 
@@ -143,6 +143,6 @@ export async function uncheckCheckbox(
     page?: Page,
 ) {
     const selector = call.request.getSelector();
-    await invokeOnPage(page, callback, 'uncheck', selector);
+    await invokeOnPageWithSelector(page, callback, 'uncheck', selector);
     callback(null, emptyWithLog('Unchecked checkbox: ' + selector));
 }

--- a/Browser/wrapper/playwirght-util.ts
+++ b/Browser/wrapper/playwirght-util.ts
@@ -11,12 +11,8 @@ export function exists<T1, T2>(obj: T1, callback: sendUnaryData<T2>, message: st
     }
 }
 
-function pageExists<T>(page: Page | undefined, callback: sendUnaryData<T>, message: string) {
-    exists(page, callback, message);
-}
-
 export async function invokeOnPage(page: Page | undefined, callback: any, methodName: string, ...args: any[]) {
-    pageExists(page, callback, `Tried to do playwirght action '${methodName}', but no open browser.`);
+    exists(page, callback, `Tried to do playwirght action '${methodName}', but no open browser.`);
     const fn: any = (page as { [key: string]: any })[methodName].bind(page);
     try {
         return await fn(...args);
@@ -24,4 +20,76 @@ export async function invokeOnPage(page: Page | undefined, callback: any, method
         console.log(`Error invoking Playwright action '${methodName}': ${e}`);
         callback(e, null);
     }
+}
+
+/**
+ * Resolve the playwright method on page or frame and invoke it.
+ * With a normal selector, invokes the `methodName` on the given `page`.
+ * If the selector is a frame piercing selector, first find the corresponding
+ * frame on the `page`, and then invoke the `methodName` on the resolved frame.
+ *
+ * @param page Existing Playwright Page object.
+ * @param callback GRPC callback to make response.
+ * @param methodName Which Playwright method to invoke.
+ * @param selector Selector of the element to operate on,
+ *  or a frame piercing selector in format `<frame selector> >>> <element selector>
+ * @param args Additional args to the Playwirght method.
+ */
+export async function invokeOnPageWithSelector<T>(
+    page: Page | undefined,
+    callback: sendUnaryData<T>,
+    methodName: string,
+    selector: string,
+    ...args: any[]
+) {
+    exists(page, callback, `Tried to do playwirght action '${methodName}', but no open browser.`);
+    const { elementSelector, fn } = await determineFunctionAndSelector(page, methodName, selector, callback);
+    try {
+        return await fn(elementSelector, ...args);
+    } catch (e) {
+        console.log(`Error invoking Playwright action '${methodName}': ${e}`);
+        callback(e, null);
+    }
+}
+
+async function determineFunctionAndSelector<T>(
+    page: Page,
+    methodName: string,
+    selector: string,
+    callback: sendUnaryData<T>,
+) {
+    if (isFramePiercingSelector(selector)) {
+        const { frameSelector, elementSelector } = splitFrameAndElementSelector(selector);
+        const frame = await findFrame(page, frameSelector, callback);
+        const fn = (frame as { [key: string]: any })[methodName].bind(frame);
+        return { elementSelector, fn };
+    } else {
+        return { elementSelector: selector, fn: (page as { [key: string]: any })[methodName].bind(page) };
+    }
+}
+
+function isFramePiercingSelector(selector: string) {
+    return selector.match('>>>');
+}
+
+function splitFrameAndElementSelector(selector: string) {
+    const parts = selector.split('>>>');
+    return {
+        frameSelector: parts[0].trim(),
+        elementSelector: parts[1].trim(),
+    };
+}
+
+async function findFrame<T>(page: Page, frameSelector: string, callback: sendUnaryData<T>) {
+    const frameHandle = await page.$(frameSelector);
+    exists(frameHandle, callback, `Could not find frame with selector ${frameSelector}`);
+    const url = await frameHandle.getAttribute('src');
+    if (url) {
+        return page.frame({ url: new RegExp(url) });
+    }
+    const name = await frameHandle.getAttribute('name');
+    if (name) {
+        return page.frame({ name: name });
+    }
+    callback(new Error(`Could not find frame with selector ${frameSelector}`), null);
 }

--- a/atest/dynamic-test-app/static/frames/iframes.html
+++ b/atest/dynamic-test-app/static/frames/iframes.html
@@ -1,3 +1,4 @@
+
 <html>
   <iframe name ="left" id="left"  src="left.html"></iframe>
   <iframe name="right" id="right" src="right.html"></iframe>

--- a/atest/dynamic-test-app/static/frames/left.html
+++ b/atest/dynamic-test-app/static/frames/left.html
@@ -2,10 +2,7 @@
   <body>
     <p>This is LEFT side. Links:</p>
     <ul>
-      <li>Open <a href="foo.html" target="right">foo</a> on the right-hand side frame
-      <li>Open <a href="bar.html" target="right">bar</a> on the right-hand side frame
-      <li>Open <a href="foo.html" target="right"><img src="foo.jpg" alt="foo" /></a> on the right-hand side frame
-      <li>Open <a href="bar.html" target="right"><img src="bar.jpg" alt="bar" /></a> on the right-hand side frame
+      <li>Open <a href="foo.html" target="right" class="link">foo</a> on the right-hand side frame
     </ul>
     <p>Form:</p>
     <form name="search_form" action="search_results.html" target="right">

--- a/atest/dynamic-test-app/static/frames/right.html
+++ b/atest/dynamic-test-app/static/frames/right.html
@@ -1,6 +1,7 @@
+
 <html>
-  <body>
-    <p>This is RIGHT side.</p>
-    <p>You're looking at <span id="page_identifier">right</span>.</p>
-  </body>
-</html>
+    <body>
+      <p>This is RIGHT side.</p>
+      <p>You're looking at <span id="page_identifier">right</span>.</p>
+    </body>
+  </html>

--- a/atest/test/04_frames/frames.robot
+++ b/atest/test/04_frames/frames.robot
@@ -1,0 +1,10 @@
+*** Settings ***
+Resource          imports.resource
+
+*** Variables ***
+${FRAMES URL}     ${ROOT URL}/frames/iframes.html
+
+*** Test Cases ***
+Assert content inside iframe
+    [Setup]    Open Browser    ${FRAMES URL}
+    Get Text    css=#left >>> .link

--- a/atest/test/04_frames/imports.resource
+++ b/atest/test/04_frames/imports.resource
@@ -1,0 +1,2 @@
+*** Settings ***
+Resource    ../keywords.resource


### PR DESCRIPTION
When selector has a special syntax <selector> >>> <another selector>,
the first part is assumed to be a frame selector and the second part an
element selector matching inside the frame.

In that case, we first resolve the frame and then invoke the
requested playwright opreation on the frame's context.